### PR TITLE
Add a set of () to call the endGame method in the event of a tie

### DIFF
--- a/game.js
+++ b/game.js
@@ -54,8 +54,8 @@ class Game {
       displayWin(player);
       this.endGame();
     } else if (!this.movesLeft) {
+      this.endGame();
       displayDraw();
-      this.endGame;
     }
 
     this.changePlayer();


### PR DESCRIPTION
Small refactor needed to be made to fix bug where the board would not reset after a draw occurs.
I had forgotten to call the endGame method inside the conditional statement for a tie.